### PR TITLE
Support: threading.Thread, gevent, eventlet, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,29 +52,25 @@ Wrapper get from flask config all parameters started from prefix "NAMEKO_" and p
 ### Example
 
 ```python
-from eventlet import monkey_patch
 from flask import Flask
-from nameko_proxy.wrappers.flask import FlaskNamekoProxy
+from nameko_proxy.wrappers.flask_wrapper import FlaskNamekoProxy
 
 
 rpc = FlaskNamekoProxy()
 
 
-def make_app(conf_path: str='settings.py') -> Flask:
+def make_app():
     app = Flask(__name__)
-    app.config.from_pyfile(conf_path)
-    return app
-    
-    
-def start_app():
-    app = make_app()
+    app.config.update(dict(
+        NAMEKO_AMQP_URI='pyamqp://guest:guest@localhost'
+    ))
     rpc.init_app(app)
-    
-    monkey_patch()
-    app.run()
+    return app
+
+app = make_app()
 
 if __name__ == '__main__':
-    start_app()
+    app.run()
 ```
 
 
@@ -85,7 +81,7 @@ It useful if you want for example add to each request unique request_id for bett
 
 ```python
 from flask import Flask, request
-from nameko_proxy.wrappers.flask import FlaskNamekoProxy
+from nameko_proxy.wrappers.flask_wrapper import FlaskNamekoProxy
 from nameko.constants import CALL_ID_STACK_CONTEXT_KEY
 
 app = Flask(__name__)

--- a/nameko_proxy/__init__.py
+++ b/nameko_proxy/__init__.py
@@ -1,4 +1,3 @@
 from nameko_proxy.proxy import *
 from nameko_proxy.reply_listener import *
 
-__version__ = '0.0.5'

--- a/nameko_proxy/event_queue.py
+++ b/nameko_proxy/event_queue.py
@@ -1,0 +1,19 @@
+from queue import Queue
+
+class EventQueue(Queue):
+
+    def send_exception(self, arg):
+        self.put({'result': None, 'exc': arg})
+
+    def send(self, result=None, exc=None):
+        self.put({'result': result, 'exc': exc})
+
+    def wait(self, timeout=None):
+        res = self.get(timeout=timeout)
+        if res['exc']:
+            raise res['exc']
+        return res['result']
+
+    def ready(self):
+        return not self.empty()
+

--- a/nameko_proxy/event_queue.py
+++ b/nameko_proxy/event_queue.py
@@ -1,6 +1,11 @@
-from queue import Queue
+from nameko.exceptions import RpcTimeout
+from queue import Queue, Empty
 
 class EventQueue(Queue):
+
+    def __init__(self, timeout=None, *args, **kwargs):
+        self.timeout = timeout
+        super(EventQueue, self).__init__(*args, **kwargs)
 
     def send_exception(self, arg):
         self.put({'result': None, 'exc': arg})
@@ -9,11 +14,14 @@ class EventQueue(Queue):
         self.put({'result': result, 'exc': exc})
 
     def wait(self, timeout=None):
-        res = self.get(timeout=timeout)
-        if res['exc']:
-            raise res['exc']
-        return res['result']
-
+        timeout = timeout if timeout is not None else self.timeout
+        try:
+            res = self.get(timeout=timeout)
+            if res['exc']:
+                raise res['exc']
+            return res['result']
+        except Empty:
+            raise RpcTimeout(timeout)
     def ready(self):
         return not self.empty()
 

--- a/nameko_proxy/proxy.py
+++ b/nameko_proxy/proxy.py
@@ -11,7 +11,7 @@ __all__ = ['StandaloneRpcProxy']
 logger = getLogger()
 
 
-class _StandaloneProxyBase:
+class _StandaloneProxyBase(object):
 
     ServiceContainer = StandaloneProxyBase.ServiceContainer
     Dummy = StandaloneProxyBase.Dummy
@@ -28,7 +28,7 @@ class _StandaloneProxyBase:
         self._reply_listener = reply_listener_cls(
             timeout=timeout).bind(self.container)
 
-    def register_context_hook(self, func: callable):
+    def register_context_hook(self, func):
         self.context_data_hooks.append(func)
 
     def __enter__(self):
@@ -46,7 +46,7 @@ class _StandaloneProxyBase:
 
 
 class _ClusterProxy:
-    def __init__(self, container, entrypoint, reply_listener, context_callback: callable):
+    def __init__(self, container, entrypoint, reply_listener, context_callback):
         self._container = container
         self._entrypoint = entrypoint
         self._reply_listener = reply_listener
@@ -68,9 +68,10 @@ class StandaloneRpcProxy(_StandaloneProxyBase):
         self._proxy = _ClusterProxy(
             self.container, self.Dummy, self._reply_listener, context_callback=self.get_context_data)
 
-    def get_context_data(self) -> dict:
+    def get_context_data(self):
         if self.context_data or self.context_data_hooks:
             context_data = self.context_data.copy() if self.context_data else {}
             for hook in self.context_data_hooks:
                 context_data.update(hook())
             return context_data
+

--- a/nameko_proxy/reply_listener.py
+++ b/nameko_proxy/reply_listener.py
@@ -12,10 +12,11 @@ class StandaloneReplyListener(ReplyListener):
     queue_consumer = None
 
     def __init__(self, timeout=None):
+        self.timeout = timeout
         self.queue_consumer = QueueConsumer(timeout)
         super(StandaloneReplyListener, self).__init__()
 
     def get_reply_event(self, correlation_id):
-        reply_event = EventQueue()
+        reply_event = EventQueue(timeout=self.timeout)
         self._reply_events[correlation_id] = reply_event
         return reply_event

--- a/nameko_proxy/reply_listener.py
+++ b/nameko_proxy/reply_listener.py
@@ -2,6 +2,8 @@ from nameko.rpc import ReplyListener
 
 from nameko_proxy.queue_consumer import QueueConsumer
 
+from nameko_proxy.event_queue import EventQueue
+
 __all__ = ['StandaloneReplyListener']
 
 
@@ -12,3 +14,8 @@ class StandaloneReplyListener(ReplyListener):
     def __init__(self, timeout=None):
         self.queue_consumer = QueueConsumer(timeout)
         super(StandaloneReplyListener, self).__init__()
+
+    def get_reply_event(self, correlation_id):
+        reply_event = EventQueue()
+        self._reply_events[correlation_id] = reply_event
+        return reply_event

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='nameko-proxy',
-    version='0.0.5',
+    version='0.0.6',
     author='Sergey Suglobov',
     author_email='s.suglobov@gmail.com',
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,9 @@
 from setuptools import setup, find_packages
 
-from nameko_proxy import __version__
-
 
 setup(
     name='nameko-proxy',
-    version=__version__,
+    version='0.0.5',
     author='Sergey Suglobov',
     author_email='s.suglobov@gmail.com',
     packages=find_packages(),

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -12,9 +12,8 @@ CONFIG = {
 
 
 @deserialize_to_instance
-class TestError(Exception):
-    def __init__(self, msg):
-        self.msg = msg
+class FooTestError(Exception):
+    pass
 
 
 class FooService(object):
@@ -26,7 +25,7 @@ class FooService(object):
 
     @rpc
     def error(self, msg):
-        raise TestError(msg)
+        raise FooTestError(msg)
 
     @rpc
     def sleep(self, seconds=0):
@@ -44,7 +43,7 @@ def test_rpc_proxy():
         msg = "Error occurred"
         try:
             proxy.foo_service.error(msg)
-        except TestError as error:
+        except FooTestError as error:
             assert str(error) == msg
 
 


### PR DESCRIPTION
This extension only works with eventlet threads.

To add support for other threads, I changed `eventlet.spawn` to `threading.Thread` and `eventlet.event.Event` to `queue.Queue`.

I tested it with gunicorn with gevent, eventlet and standard threads.